### PR TITLE
feat: add text marshal/unmarshal

### DIFF
--- a/account.go
+++ b/account.go
@@ -138,6 +138,17 @@ func (c *AccountID) UnmarshalGQL(v interface{}) error {
 	return nil
 }
 
+func (c AccountID) MarshalText() ([]byte, error) {
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(c.String()), nil
+}
+
+func (c *AccountID) UnmarshalText(data []byte) error {
+	return c.Parse(string(data))
+}
+
 type EVMAccountID struct {
 	EVMAddressable
 	AccountID

--- a/asset.go
+++ b/asset.go
@@ -146,6 +146,17 @@ func (a *AssetID) UnmarshalGQL(v interface{}) error {
 	return nil
 }
 
+func (a AssetID) MarshalText() ([]byte, error) {
+	if err := a.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(a.String()), nil
+}
+
+func (a *AssetID) UnmarshalText(data []byte) error {
+	return a.Parse(string(data))
+}
+
 type EVMAssetID struct {
 	EVMAddressable
 	AssetID

--- a/chain.go
+++ b/chain.go
@@ -132,3 +132,14 @@ func (c *ChainID) UnmarshalGQL(v interface{}) error {
 
 	return nil
 }
+
+func (c ChainID) MarshalText() ([]byte, error) {
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(c.String()), nil
+}
+
+func (c *ChainID) UnmarshalText(data []byte) error {
+	return c.Parse(string(data))
+}

--- a/chain.go
+++ b/chain.go
@@ -75,6 +75,11 @@ func (c *ChainID) ParseX(s string) {
 }
 
 func (c *ChainID) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		return c.Parse(str)
+	}
+
 	type ChainIDAlias ChainID
 	ca := (*ChainIDAlias)(c)
 	if err := json.Unmarshal(data, &ca); err != nil {

--- a/chain.go
+++ b/chain.go
@@ -77,7 +77,7 @@ func (c *ChainID) ParseX(s string) {
 func (c *ChainID) UnmarshalJSON(data []byte) error {
 	var str string
 	if err := json.Unmarshal(data, &str); err == nil {
-		return c.Parse(str)
+		return c.UnmarshalText([]byte(str))
 	}
 
 	type ChainIDAlias ChainID


### PR DESCRIPTION
- Added `MarshalText` and `UnmarshalText`. 
- Updated `UnmarshalJSON` for ChainID to support unmarshaling a string format e.g. `eip155:1` and not only an object format `{"namespace":"eip155","reference":"1"}`